### PR TITLE
Update clickhouse port for FastAPI service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         condition: service_healthy
     environment:
       - CLICKHOUSE_HOST=clickhouse
-      - CLICKHOUSE_PORT=8123
+      - CLICKHOUSE_PORT=9000
       - CLICKHOUSE_USER=myuser
       - CLICKHOUSE_PASSWORD=my_password  
       - CLICKHOUSE_DATABASE=default


### PR DESCRIPTION
## Summary
- set `CLICKHOUSE_PORT` to `9000` for the FastAPI container

## Testing
- `docker-compose up -d --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6886f2be5390832ba10238f4e4ef5a57