### PR TITLE
Use lifespan for ClickHouse client

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,16 @@
 from fastapi import FastAPI, Depends
 from fastapi.security import OAuth2PasswordBearer
+from contextlib import asynccontextmanager
 from app.routers import auth, articles
 from app.core.config import settings
+from app.services.clickhouse_client import ClickHouseClient
 
-app = FastAPI(title="FastAPI ClickHouse API")
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    app.state.clickhouse = ClickHouseClient()
+    yield
+
+app = FastAPI(title="FastAPI ClickHouse API", lifespan=lifespan)
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/login")
 

--- a/app/routers/articles.py
+++ b/app/routers/articles.py
@@ -1,43 +1,71 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from typing import List
 from app.models.article import Article, ArticleCreate
-from app.services.clickhouse_client import clickhouse_client
 from app.core.security import get_current_user
 
 router = APIRouter(prefix="/articles", tags=["articles"])
 
 @router.post("/", response_model=Article)
-async def create_article(article: ArticleCreate, current_user: str = Depends(get_current_user)):
-    clickhouse_client.insert_article(article.title, article.content)
-    article_id = clickhouse_client._get_next_id() - 1
-    result = clickhouse_client.get_article(article_id)
+async def create_article(
+    request: Request,
+    article: ArticleCreate,
+    current_user: str = Depends(get_current_user),
+):
+    client = request.app.state.clickhouse
+    client.insert_article(article.title, article.content)
+    article_id = client._get_next_id() - 1
+    result = client.get_article(article_id)
     if not result:
         raise HTTPException(status_code=404, detail="Article not found")
     return {"id": result[0], "title": result[1], "content": result[2], "created_at": result[3]}
 
 @router.get("/", response_model=List[Article])
-async def read_articles(skip: int = 0, limit: int = 10, current_user: str = Depends(get_current_user)):
-    results = clickhouse_client.get_articles(skip, limit)
-    return [{"id": r[0], "title": r[1], "content": r[2], "created_at": r[3]} for r in results]
+async def read_articles(
+    request: Request,
+    skip: int = 0,
+    limit: int = 10,
+    current_user: str = Depends(get_current_user),
+):
+    client = request.app.state.clickhouse
+    results = client.get_articles(skip, limit)
+    return [
+        {"id": r[0], "title": r[1], "content": r[2], "created_at": r[3]} for r in results
+    ]
 
 @router.get("/{article_id}", response_model=Article)
-async def read_article(article_id: int, current_user: str = Depends(get_current_user)):
-    result = clickhouse_client.get_article(article_id)
+async def read_article(
+    request: Request,
+    article_id: int,
+    current_user: str = Depends(get_current_user),
+):
+    client = request.app.state.clickhouse
+    result = client.get_article(article_id)
     if not result:
         raise HTTPException(status_code=404, detail="Article not found")
     return {"id": result[0], "title": result[1], "content": result[2], "created_at": result[3]}
 
 @router.put("/{article_id}", response_model=Article)
-async def update_article(article_id: int, article: ArticleCreate, current_user: str = Depends(get_current_user)):
-    clickhouse_client.update_article(article_id, article.title, article.content)
-    result = clickhouse_client.get_article(article_id)
+async def update_article(
+    request: Request,
+    article_id: int,
+    article: ArticleCreate,
+    current_user: str = Depends(get_current_user),
+):
+    client = request.app.state.clickhouse
+    client.update_article(article_id, article.title, article.content)
+    result = client.get_article(article_id)
     if not result:
         raise HTTPException(status_code=404, detail="Article not found")
     return {"id": result[0], "title": result[1], "content": result[2], "created_at": result[3]}
 
 @router.delete("/{article_id}")
-async def delete_article(article_id: int, current_user: str = Depends(get_current_user)):
-    result = clickhouse_client.delete_article(article_id)
+async def delete_article(
+    request: Request,
+    article_id: int,
+    current_user: str = Depends(get_current_user),
+):
+    client = request.app.state.clickhouse
+    result = client.delete_article(article_id)
     if not result:
         raise HTTPException(status_code=404, detail="Article not found")
     return {"message": "Article deleted"}

--- a/app/services/clickhouse_client.py
+++ b/app/services/clickhouse_client.py
@@ -67,5 +67,3 @@ class ClickHouseClient:
     def _get_next_id(self):
         result = self.client.execute("SELECT max(id) FROM articles")
         return (result[0][0] + 1) if result[0][0] else 1
-
-clickhouse_client = ClickHouseClient()


### PR DESCRIPTION
## Summary
- remove global ClickHouse client instance
- create ClickHouse client during FastAPI startup via lifespan
- use `request.app.state.clickhouse` in article routes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6886f2aa57c8832bbada24d559708e07